### PR TITLE
Fixed bug for parser to accept only port numbers that are non negative ints

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -178,6 +178,20 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           config_stack.top()->statements_.emplace_back(
               new NginxConfigStatement);
         }
+        else {
+          bool intCheck = false;
+          bool alphaCheck = false;
+          for(int i = 0; i < token.size(); i++){
+            if(i==0 && token[i] == '-')
+              alphaCheck = true;
+            if(isalpha(token[i]))
+              alphaCheck = true;
+            if(isdigit(token[i]))
+              intCheck = true;
+          }
+          if(intCheck && alphaCheck)
+            break;
+        }
         config_stack.top()->statements_.back().get()->tokens_.push_back(
             token);
       } else {

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -9,3 +9,44 @@ TEST(NginxConfigParserTest, SimpleConfig) {
 
   EXPECT_TRUE(success);
 }
+
+class NginxStringConfigTest : public ::testing::Test {
+protected:
+	bool ParseString(const std::string config_string){
+		std::stringstream config_stream(config_string);
+		return parser_.Parse(&config_stream, &out_config_);
+	}
+	NginxConfigParser parser_;
+	NginxConfig out_config_;
+};
+
+TEST_F(NginxStringConfigTest, AnotherSimpleConfig){
+	EXPECT_TRUE(ParseString("foo bar;"));
+	EXPECT_EQ(1, out_config_.statements_.size());
+	EXPECT_EQ("foo", out_config_.statements_.at(0)->tokens_.at(0));
+}
+
+TEST_F(NginxStringConfigTest, InvalidConfig) {
+	EXPECT_FALSE(ParseString("foo bar"));
+}
+
+TEST_F(NginxStringConfigTest, NestedConfig) {
+	EXPECT_TRUE(ParseString("server { listen 80; }"));
+	// TODO: Test the contents of out_config_;
+}
+
+TEST_F(NginxStringConfigTest, EmptyConfig) {
+	EXPECT_FALSE(ParseString("server { };"));
+}
+
+TEST_F(NginxStringConfigTest, semicolonError){
+	EXPECT_FALSE(ParseString("server { listen 80 }"));
+}
+
+TEST_F(NginxStringConfigTest, negativePortError){
+	EXPECT_FALSE(ParseString("server { listen -80; }"));
+}
+
+TEST_F(NginxStringConfigTest, noSpacesError){
+	EXPECT_TRUE(ParseString("server {listen 80;}"));
+}


### PR DESCRIPTION
Fixed bug for parser to accept only port numbers that are non-negative ints
Wrote unit tests for config_parser.cc